### PR TITLE
Improve and sync AS and JS versions

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -10,11 +10,11 @@
     "release": {
       "binaryFile": "build/optimized.wasm",
       "textFile": "build/optimized.wat",
-      "sourceMap": true,
       "optimizeLevel": 3,
-      "shrinkLevel": 1,
-      "converge": false,
-      "noAssert": false,
+      "shrinkLevel": 0,
+      "converge": true,
+      "noAssert": true,
+      "sourceMap": true,
       "exportRuntime": true
     }
   },

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,36 +1,38 @@
 // The entry file of your WebAssembly module.
 
+export const Int32Array_ID = idof<Int32Array>();
+export const Float64Array_ID = idof<Float64Array>();
+
 export function add(a: i32, b: i32): i32 {
   return a + b;
 }
 
-export function factorial(i: f64): f64 {
-  if (i == 0) return 1;
-  return i * factorial(i - 1);
+export function factorial(i: i32): i32 {
+  return i == 0 ? 1 : i * factorial(i - 1);
 }
 
 export function squareArray(arr: Int32Array): Int32Array {
-  const result = new Int32Array(arr.length);
-  for (let i = 0; i < arr.length; ++i) {
-    unchecked((result[i] = arr[i] * arr[i]));
+  const len = arr.length;
+  const result = new Int32Array(len);
+  for (let i = 0; i < len; ++i) {
+    const e = unchecked(arr[i]);
+    unchecked(result[i] = e * e);
   }
   return result;
 }
 
-export const Int32Array_ID = idof<Int32Array>();
 
 export function calcSinLookup(): Float64Array {
   const max = 6283;
   const result = new Float64Array(max);
 
   for (let i = 0; i < max; ++i) {
-    result[i] = Math.sin(i * 0.001);
+    unchecked(result[i] = Math.sin(i * 0.001));
   }
 
   return result;
 }
 
-export const Float64Array_ID = idof<Float64Array>();
 
 declare namespace test {
   @external("test", "importCallback")
@@ -38,7 +40,7 @@ declare namespace test {
 }
 
 export function testImport(n: i32): i32 {
-  let result: i32 = 0;
+  let result = 0;
   for (let i = 1; i <= n; ++i) {
     result = test.importCallback(result, i);
   }

--- a/benchmarks.js
+++ b/benchmarks.js
@@ -34,8 +34,7 @@ function addTest() {
 
 function factorialTest() {
   function factorialJs(i) {
-    if (i == 0) return 1;
-    return i * factorialJs(i - 1);
+    return i == 0 ? 1 : i * factorialJs(i - 1);
   }
   const factorialAs = wasm.factorial;
 
@@ -61,8 +60,7 @@ function squareArrayTest() {
 
   const test = new Benchmark.Suite("squareArray");
 
-  const array = new Array(200);
-  array.fill(2);
+  const array = new Int32Array(200).fill(2);
 
   // console.log(squareArrayAs(array));
 
@@ -79,7 +77,7 @@ function squareArrayTest() {
 function calcSinLookupTest() {
   function calcSinLookupJs() {
     const max = 6283;
-    const result = new Array(max);
+    const result = new Float64Array(max);
 
     for (let i = 0; i < max; ++i) {
       result[i] = Math.sin(i * 0.001);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const wasmModule = loader.instantiateSync(
 function squareArrayWrap(array) {
   const {
     __newArray,
-    __getArray,
+    __getInt32Array,
 
     Int32Array_ID,
     squareArray,
@@ -27,21 +27,18 @@ function squareArrayWrap(array) {
 
   const arr = __newArray(Int32Array_ID, array);
 
-  const result = __getArray(squareArray(arr));
+  const result = __getInt32Array(squareArray(arr));
 
   return result;
 }
 
 function calcSinLookupWrap() {
   const {
-    __getArray,
+    __getFloat64Array,
 
     calcSinLookup,
   } = wasmModule.exports;
-
-  const result = __getArray(calcSinLookup());
-
-  return result;
+  return __getFloat64Array(calcSinLookup());
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "as-hello",
+  "name": "assemblyscript-benchmarks",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
I would like suggest some improvements. Also I guess better use same data structures on JS and AS side, so I changed usual arrays to typed arrays on JS side.

Note basically for such simple benchmarks on JS side you're usually measure interop overhead instead actual wasm performance but you probably are aware of this.

Anther suggestion. I recommend exclude array creation for `calcSinLookup` or create it globally and once and rewrite it every benchmark stage. In this case you could compare JS and AS math more properly

master (before):
```
Benchmarking add:
AssemblyScript x 152,771,389 ops/sec ±0.67% (89 runs sampled)
JavaScript x 872,744,847 ops/sec ±1.10% (85 runs sampled)
JavaScript is faster

Benchmarking factorial:
AssemblyScript x 11,824,147 ops/sec ±1.04% (92 runs sampled)
JavaScript x 6,813,119 ops/sec ±0.64% (94 runs sampled)
AssemblyScript is faster

Benchmarking squareArray:
AssemblyScript x 305,892 ops/sec ±1.18% (91 runs sampled)
JavaScript x 2,167,033 ops/sec ±0.79% (91 runs sampled)
JavaScript is faster

Benchmarking calcSinLookup:
AssemblyScript x 12,320 ops/sec ±0.65% (91 runs sampled)
JavaScript x 12,372 ops/sec ±0.67% (95 runs sampled)
JavaScript,AssemblyScript is faster

Benchmarking importCallback:
AssemblyScript x 29,308 ops/sec ±0.35% (94 runs sampled)
JavaScript x 419,580 ops/sec ±0.41% (96 runs sampled)
JavaScript is faster
```

with this PR (after):
```
Benchmarking add:
AssemblyScript x 156,504,221 ops/sec ±0.64% (91 runs sampled)
JavaScript x 893,287,993 ops/sec ±1.49% (87 runs sampled)
JavaScript is faster

Benchmarking factorial:
AssemblyScript x 12,210,579 ops/sec ±0.84% (95 runs sampled)
JavaScript x 6,838,418 ops/sec ±0.71% (94 runs sampled)
AssemblyScript is faster

Benchmarking squareArray:
AssemblyScript x 458,934 ops/sec ±1.25% (88 runs sampled)
JavaScript x 299,228 ops/sec ±3.15% (85 runs sampled)
AssemblyScript is faster

Benchmarking calcSinLookup:
AssemblyScript x 11,483 ops/sec ±1.19% (86 runs sampled)
JavaScript x 10,091 ops/sec ±0.58% (92 runs sampled)
AssemblyScript is faster

Benchmarking importCallback:
AssemblyScript x 29,004 ops/sec ±0.81% (94 runs sampled)
JavaScript x 419,500 ops/sec ±0.32% (98 runs sampled)
JavaScript is faster
```